### PR TITLE
Test more env on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+sudo: false
 language: node_js
 node_js:
-  - '0.10'
+  - iojs
+  - "0.12"
+  - "0.10"


### PR DESCRIPTION
* `sudo: false` enables Docker mode, which increase test speed.
* Also I add more node.js/io.js environment, because they are popular and should be supported by any npm package.

/cc @w0rm